### PR TITLE
added an initial battle transition animation as an example

### DIFF
--- a/src/characters/girl-character.ts
+++ b/src/characters/girl-character.ts
@@ -3,6 +3,7 @@ let cursors: Phaser.Types.Input.Keyboard.CursorKeys;
 const playerSpeed = 100;
 
 export default class GirlCharacter extends Phaser.Physics.Arcade.Sprite {
+  shouldHandleInput: boolean = true;
   previousVelocity: Phaser.Math.Vector2;
   previousAngle: number;
 
@@ -11,10 +12,21 @@ export default class GirlCharacter extends Phaser.Physics.Arcade.Sprite {
 
     scene.add.existing(this);
     scene.physics.add.existing(this);
+    scene.events.addListener(
+      'OverworldState.OS_BattleTransition',
+      this.handleBattleTransition,
+      this
+    );
 
     this.anims.play('facedown');
 
     cursors = scene.input.keyboard.createCursorKeys();
+  }
+
+  private handleBattleTransition() {
+    this.setActive(false);
+    this.body.velocity.x = 0;
+    this.body.velocity.y = 0;
   }
 
   private updateMovement() {

--- a/src/characters/girl-character.ts
+++ b/src/characters/girl-character.ts
@@ -3,7 +3,6 @@ let cursors: Phaser.Types.Input.Keyboard.CursorKeys;
 const playerSpeed = 100;
 
 export default class GirlCharacter extends Phaser.Physics.Arcade.Sprite {
-  shouldHandleInput: boolean = true;
   previousVelocity: Phaser.Math.Vector2;
   previousAngle: number;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,7 @@ const gameConfig: Phaser.Types.Core.GameConfig = {
     pixelArt: true,
   },
   parent: 'game',
-  scene: OverworldScene,
+  scene: [OverworldScene, BattleScene],
   backgroundColor: '#333333',
 };
 

--- a/src/scenes/battle-scene.tsx
+++ b/src/scenes/battle-scene.tsx
@@ -8,7 +8,7 @@ import { bootstrapAnimations } from '../utils';
 const sceneConfig: Phaser.Types.Scenes.SettingsConfig = {
   active: false,
   visible: false,
-  key: 'Game',
+  key: 'battle',
 };
 
 export default class BattleScene extends Phaser.Scene {

--- a/src/scenes/overworld-scene.ts
+++ b/src/scenes/overworld-scene.ts
@@ -1,7 +1,6 @@
 import data from '../data/animations/girl';
 import { bootstrapAnimations } from '../utils';
 import GirlCharacter from '../characters/girl-character';
-import { collapseTextChangeRangesAcrossMultipleVersions } from 'typescript';
 
 const sceneConfig: Phaser.Types.Scenes.SettingsConfig = {
   active: false,

--- a/src/scenes/overworld-scene.ts
+++ b/src/scenes/overworld-scene.ts
@@ -46,6 +46,7 @@ export default class OverworldScene extends Phaser.Scene {
     this.cameras.main.setZoom(4);
   }
 
+  // refactor ->> "Battle / Encounter" System should determine this
   private shouldEnterBattle() {
     // distance player should move between rolls
     const stepDistance = 1000;
@@ -75,11 +76,14 @@ export default class OverworldScene extends Phaser.Scene {
 
   private updatePlay() {
     if (this.shouldEnterBattle()) {
-      // refactor ->> move to separatte ts module, export event name
+      // refactor ->> move to separate ts module, export event name
       // events/overworld/BATTLE_TRANSITION
       this.events.emit('OverworldState.OS_BattleTransition');
 
       this.overworldState = OverworldState.OS_BattleTransition;
+
+      // refactor ->> this should be data driven
+      // e.g., TransitionAnimation { [Animations/Effects], NextScene };
 
       // flash
       this.cameras.main.addListener(


### PR DESCRIPTION
Added an initial battle transition animation, as sort of an example.

the "shouldEnterBattle" method, and pipework are all mainly demo and should be refactored when the appropriate underlying/prerequisite systems are built. 